### PR TITLE
PAT-371: Upgrade Monolith Ruby version to Latest Stable

### DIFF
--- a/lib/apipie/extractor/recorder.rb
+++ b/lib/apipie/extractor/recorder.rb
@@ -150,8 +150,8 @@ module Apipie
       end
 
       module FunctionalTestRecording
-        def process(*args) # action, parameters = nil, session = nil, flash = nil, http_method = 'GET')
-          ret = super(*args)
+        def process(*) # action, parameters = nil, session = nil, flash = nil, http_method = 'GET')
+          ret = super
           if Apipie.configuration.record
             Apipie::Extractor.call_recorder.analyze_functional_test(self)
             Apipie::Extractor.call_finished
@@ -160,6 +160,8 @@ module Apipie
         ensure
           Apipie::Extractor.clean_call_recorder
         end
+        # Taking this from https://github.com/Apipie/apipie-rails/blob/master/lib/apipie/extractor/recorder.rb#L189C1-L190C1
+        ruby2_keywords :process if respond_to?(:ruby2_keywords, true)
       end
     end
   end


### PR DESCRIPTION
This updates the Apipie `lib/apipie/extractor/recorder.rb` to support the new Ruby 3.0.7 upgrade on pathLMS

This is the description on the update https://github.com/Apipie/apipie-rails/commit/a55d836f4e8609395c374d85b2542a3ac7277a2c

### Controller specs on Path LMS after patching this:

```
gtrujillop:~/bse/path-lms (ruby-3.0.7) [PAT-371-ruby-upgrade] $ bundle exec rspec ./spec/foundational/controllers/lock_users_controller_spec.rb
warning: parser/current is loading parser/ruby30, which recognizes 3.0.6-compliant syntax, but you are running 3.0.7.
Please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
/home/gtrujillop/bse/path-lms/config/initializers/sidekiq.rb:52: warning: Sidekiq's Delayed Extensions will be removed in Sidekiq 7.0
WARNING: `around(:context)` hooks are not supported and behave like `around(:example). Called from /home/gtrujillop/bse/path-lms/spec/spec_helper.rb:320:in `block in <top (required)>'.

Randomized with seed 42260

.........

Finished in 3.07 seconds (files took 23.59 seconds to load)
19 examples, 0 failures

Randomized with seed 42260
```
